### PR TITLE
Feature request: adjust the name based off of AWS_ENVIRONMENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ AWS_QUEUE_URL=<queue-url> AWS_FUNCTION_NAME=<function-name> AWS_REGION=<aws-regi
 
 > Note that if both environment variables are set and arguments are passed as flags, the arguments take precedence.
 
+Additionally, when you have set `AWS_ENVIRONMENT` we will automatically append this behind your `<function-name>`.
+
 ## SQS message format
 
 The SQS message body should be in JSON format. The content of the message is passed to your Lambda function as its first argument. For example:

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var debug = require('debug')('sqs-to-lambda');
 var region = argv.region;
 var queueUrl = argv.queueUrl;
 var functionName = argv.functionName;
+var environment = argv.environment;
 
 if(typeof queueUrl === 'object') {
   queueUrl = queueUrl[0];
@@ -17,6 +18,9 @@ if(typeof region === 'object') {
 }
 if(typeof functionName === 'object') {
   functionName = functionName[0];
+}
+if(environment) {
+  functionName += '-' + environment;
 }
 
 if (!region || !queueUrl || !functionName) {


### PR DESCRIPTION
I'm trying to automatically tie this function in with node-lambda, unfortunately they have some logic that automatically appends the `AWS_ENVIRONMENT` to the `FunctionName`:
https://github.com/motdotla/node-lambda/blob/master/lib/main.js#L71

I didn't see a reason for not doing this with `sqs-to-lambda` as well, so I've added code that makes this possible. Hopefully it's useful for others as well.
